### PR TITLE
feat: add course detail models and update database schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -363,3 +363,4 @@ MigrationBackup/
 FodyWeavers.xsd
 /SyllabusAPI/appsettings.Local.json
 /migration.sql
+/.vscode

--- a/Syllabus.ApiContracts/Courses/CourseDetailRequestApiDTO.cs
+++ b/Syllabus.ApiContracts/Courses/CourseDetailRequestApiDTO.cs
@@ -1,0 +1,90 @@
+using Syllabus.Domain.Sylabusses;
+
+namespace Syllabus.ApiContracts.Courses
+{
+    /// <summary>
+    /// Request model for creating or updating course details.
+    /// </summary>
+    public class CourseDetailRequestApiDTO
+    {
+        /// <summary>
+        /// The academic program this course belongs to.
+        /// </summary>
+        public string AcademicProgram { get; set; } = default!;
+
+        /// <summary>
+        /// The academic year for this course.
+        /// </summary>
+        public string AcademicYear { get; set; } = default!;
+
+        /// <summary>
+        /// The language in which the course is taught.
+        /// </summary>
+        public string Language { get; set; } = default!;
+
+        /// <summary>
+        /// The label describing the course type.
+        /// </summary>
+        public string CourseTypeLabel { get; set; } = default!;
+
+        /// <summary>
+        /// The ethics code associated with the course.
+        /// </summary>
+        public string EthicsCode { get; set; } = default!;
+
+        /// <summary>
+        /// The method of examination for the course.
+        /// </summary>
+        public string ExamMethod { get; set; } = default!;
+
+        /// <summary>
+        /// The format of teaching for the course.
+        /// </summary>
+        public string TeachingFormat { get; set; } = default!;
+
+        /// <summary>
+        /// The number of credits for the course.
+        /// </summary>
+        public int Credits { get; set; }
+
+        /// <summary>
+        /// The teaching plan for the course.
+        /// </summary>
+        public TeachingPlan TeachingPlan { get; set; } = new();
+
+        /// <summary>
+        /// The evaluation breakdown for the course.
+        /// </summary>
+        public EvaluationBreakdown EvaluationBreakdown { get; set; } = new();
+
+        /// <summary>
+        /// The objective of the course.
+        /// </summary>
+        public string Objective { get; set; } = default!;
+
+        /// <summary>
+        /// The key concepts covered in the course.
+        /// </summary>
+        public string KeyConcepts { get; set; } = default!;
+
+        /// <summary>
+        /// The prerequisites for the course.
+        /// </summary>
+        public string Prerequisites { get; set; } = default!;
+
+        /// <summary>
+        /// The skills acquired through the course.
+        /// </summary>
+        public string SkillsAcquired { get; set; } = default!;
+
+        /// <summary>
+        /// The list of topics covered in the course.
+        /// </summary>
+        public List<TopicRequestApiDTO>? Topics { get; set; }
+
+        /// <summary>
+        /// The name of the course responsible.
+        /// </summary>
+        public string? CourseResponsible { get; set; }
+    }
+} 

--- a/Syllabus.ApiContracts/Courses/CreateCourseRequestApiDTO.cs
+++ b/Syllabus.ApiContracts/Courses/CreateCourseRequestApiDTO.cs
@@ -56,5 +56,10 @@ namespace Syllabus.ApiContracts.Courses
         /// The ID of the syllabus to which this course belongs.
         /// </summary>
         public int SyllabusId { get; set; }
+
+        /// <summary>
+        /// Optional course details to be created along with the course.
+        /// </summary>
+        public CourseDetailRequestApiDTO? Detail { get; set; }
     }
 }

--- a/Syllabus.ApiContracts/Courses/TopicRequestApiDTO.cs
+++ b/Syllabus.ApiContracts/Courses/TopicRequestApiDTO.cs
@@ -1,0 +1,20 @@
+﻿/// <summary>
+/// Request model for creating or updating course topics.
+/// </summary>
+public class TopicRequestApiDTO
+{
+    /// <summary>
+    /// The title of the topic.
+    /// </summary>
+    public string Title { get; set; } = default!;
+
+    /// <summary>
+    /// The number of hours allocated for this topic.
+    /// </summary>
+    public int Hours { get; set; }
+
+    /// <summary>
+    /// Optional reference materials for this topic.
+    /// </summary>
+    public string? Reference { get; set; }
+}

--- a/Syllabus.Application/Courses/AddDetail/AddCourseDetailCommand.cs
+++ b/Syllabus.Application/Courses/AddDetail/AddCourseDetailCommand.cs
@@ -1,0 +1,79 @@
+using ErrorOr;
+using MediatR;
+using Syllabus.ApiContracts.Courses;
+using Syllabus.Domain.Sylabusses;
+
+namespace Syllabus.Application.Courses.AddDetail
+{
+    public record AddCourseDetailCommand(int CourseId, CourseDetailRequestApiDTO Request) : IRequest<ErrorOr<CourseResponseApiDTO>>;
+
+    public class AddCourseDetailCommandHandler : IRequestHandler<AddCourseDetailCommand, ErrorOr<CourseResponseApiDTO>>
+    {
+        private readonly ICourseRepository _courseRepository;
+
+        public AddCourseDetailCommandHandler(ICourseRepository courseRepository)
+        {
+            _courseRepository = courseRepository;
+        }
+
+        public async Task<ErrorOr<CourseResponseApiDTO>> Handle(AddCourseDetailCommand request, CancellationToken cancellationToken)
+        {
+            var course = await _courseRepository.GetByIdAsync(request.CourseId);
+
+            if (course is null)
+            {
+                return Error.NotFound(description: $"Course with ID {request.CourseId} not found.");
+            }
+
+            if (course.Detail is not null)
+            {
+                return Error.Conflict(description: $"Course with ID {request.CourseId} already has details.");
+            }
+
+            var courseDetail = new CourseDetail
+            {
+                CourseId = request.CourseId,
+                AcademicProgram = request.Request.AcademicProgram,
+                AcademicYear = request.Request.AcademicYear,
+                Language = request.Request.Language,
+                CourseTypeLabel = request.Request.CourseTypeLabel,
+                EthicsCode = request.Request.EthicsCode,
+                ExamMethod = request.Request.ExamMethod,
+                TeachingFormat = request.Request.TeachingFormat,
+                Credits = request.Request.Credits,
+                TeachingPlan = request.Request.TeachingPlan,
+                EvaluationBreakdown = request.Request.EvaluationBreakdown,
+                Objective = request.Request.Objective,
+                KeyConcepts = request.Request.KeyConcepts,
+                Prerequisites = request.Request.Prerequisites,
+                SkillsAcquired = request.Request.SkillsAcquired,
+                CourseResponsible = request.Request.CourseResponsible
+            };
+
+            if (request.Request.Topics is not null)
+            {
+                courseDetail.Topics = request.Request.Topics.Select(t => new Topic
+                {
+                    Title = t.Title,
+                    Hours = t.Hours,
+                    Reference = t.Reference
+                }).ToList();
+            }
+
+            course.Detail = courseDetail;
+            await _courseRepository.AddDetailAsync(courseDetail);
+            await _courseRepository.SaveChangesAsync();
+
+            return new CourseResponseApiDTO
+            {
+                Id = course.Id,
+                Title = course.Title,
+                Code = course.Code,
+                Semester = course.Semester,
+                Credits = course.Credits,
+                DetailObjective = course.Detail.Objective,
+                Topics = course.Detail.Topics?.Select(t => t.Title).ToList() ?? new()
+            };
+        }
+    }
+}

--- a/Syllabus.Application/Courses/Create/CreateCourseCommand.cs
+++ b/Syllabus.Application/Courses/Create/CreateCourseCommand.cs
@@ -40,6 +40,38 @@ namespace Syllabus.Application.Courses.Create
                 Type = request.Request.Type
             };
 
+            if (request.Request.Detail is not null)
+            {
+                course.Detail = new CourseDetail
+                {
+                    AcademicProgram = request.Request.Detail.AcademicProgram,
+                    AcademicYear = request.Request.Detail.AcademicYear,
+                    Language = request.Request.Detail.Language,
+                    CourseTypeLabel = request.Request.Detail.CourseTypeLabel,
+                    EthicsCode = request.Request.Detail.EthicsCode,
+                    ExamMethod = request.Request.Detail.ExamMethod,
+                    TeachingFormat = request.Request.Detail.TeachingFormat,
+                    Credits = request.Request.Detail.Credits,
+                    TeachingPlan = request.Request.Detail.TeachingPlan,
+                    EvaluationBreakdown = request.Request.Detail.EvaluationBreakdown,
+                    Objective = request.Request.Detail.Objective,
+                    KeyConcepts = request.Request.Detail.KeyConcepts,
+                    Prerequisites = request.Request.Detail.Prerequisites,
+                    SkillsAcquired = request.Request.Detail.SkillsAcquired,
+                    CourseResponsible = request.Request.Detail.CourseResponsible
+                };
+
+                if (request.Request.Detail.Topics is not null)
+                {
+                    course.Detail.Topics = request.Request.Detail.Topics.Select(t => new Topic
+                    {
+                        Title = t.Title,
+                        Hours = t.Hours,
+                        Reference = t.Reference
+                    }).ToList();
+                }
+            }
+
             syllabus.Courses.Add(course);
             await _courseRepository.AddAsync(course);
             await _courseRepository.SaveChangesAsync();
@@ -51,8 +83,8 @@ namespace Syllabus.Application.Courses.Create
                 Code = course.Code,
                 Semester = course.Semester,
                 Credits = course.Credits,
-                Topics = new(),
-                DetailObjective = null
+                DetailObjective = course.Detail?.Objective,
+                Topics = course.Detail?.Topics?.Select(t => t.Title).ToList() ?? new()
             };
         }
     }

--- a/Syllabus.Domain/Sylabusses/CourseDetail.cs
+++ b/Syllabus.Domain/Sylabusses/CourseDetail.cs
@@ -26,6 +26,9 @@
         public string Prerequisites { get; set; }
         public string SkillsAcquired { get; set; }
 
+        // Pergjegjesi i lëndës
+        public string? CourseResponsible { get; set; }
+
         public ICollection<Topic>? Topics { get; set; } = new List<Topic>();
     }
 

--- a/Syllabus.Infrastructure/Migrations/20250502232540_CourseDetailResponsible.Designer.cs
+++ b/Syllabus.Infrastructure/Migrations/20250502232540_CourseDetailResponsible.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Syllabus.Infrastructure.Data;
 
@@ -11,9 +12,11 @@ using Syllabus.Infrastructure.Data;
 namespace Syllabus.Infrastructure.Migrations
 {
     [DbContext(typeof(SyllabusDbContext))]
-    partial class SyllabusDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250502232540_CourseDetailResponsible")]
+    partial class CourseDetailResponsible
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Syllabus.Infrastructure/Migrations/20250502232540_CourseDetailResponsible.cs
+++ b/Syllabus.Infrastructure/Migrations/20250502232540_CourseDetailResponsible.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Syllabus.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class CourseDetailResponsible : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "CourseResponsible",
+                table: "CourseDetails",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CourseResponsible",
+                table: "CourseDetails");
+        }
+    }
+}


### PR DESCRIPTION
- Added `CourseDetailRequestApiDTO` for course detail requests.
- Modified `CreateCourseRequestApiDTO` to include optional `Detail`.
- Introduced `TopicRequestApiDTO` for course topic requests.
- Enhanced `AddCourseDetailCommand` to handle course details.
- Updated `CreateCourseCommand` to manage optional course details.
- Added `CourseResponsible` property to `CourseDetail`.
- Updated migration files to add `CourseResponsible` column in `CourseDetails`.
- Reflected changes in `SyllabusDbContextModelSnapshot`.