### PR TITLE
fix: update CORS policy to allow additional origin

### DIFF
--- a/SyllabusAPI/Program.cs
+++ b/SyllabusAPI/Program.cs
@@ -31,7 +31,10 @@ builder.Services.AddCors(options =>
     options.AddPolicy("AllowReactApp",
         builder =>
         {
-            builder.WithOrigins("http://localhost:3000") // Your React app's URL
+            builder.WithOrigins(
+                "http://localhost:3000",
+                "https://syllabus-client-container.yellowfield-b94f6044.westus2.azurecontainerapps.io"
+            )
                    .AllowAnyMethod()
                    .AllowAnyHeader()
                    .AllowCredentials();


### PR DESCRIPTION
Modified the CORS policy in `Program.cs` to include "https://syllabus-client-container.yellowfield-b94f6044.westus2.azurecontainerapps.io" as an allowed origin, in addition to "http://localhost:3000". This change enables cross-origin requests from both the local development environment and the specified Azure container app URL.