### PR TITLE
fix: make ProfilePictureUrl nullable in UserEntity

### DIFF
--- a/Syllabus.Domain/Users/UserEntity.cs
+++ b/Syllabus.Domain/Users/UserEntity.cs
@@ -12,7 +12,7 @@ namespace Syllabus.Domain.Users
 
         public PhoneNumber PhoneNumberInfo { get; set; }
 
-        public string ProfilePictureUrl { get; set; }
+        public string? ProfilePictureUrl { get; set; }
 
         public UserStatus Status { get; set; } = UserStatus.Active;
     }

--- a/Syllabus.Infrastructure/Data/Configuration/UserEntityConfiguration.cs
+++ b/Syllabus.Infrastructure/Data/Configuration/UserEntityConfiguration.cs
@@ -24,7 +24,8 @@ namespace Syllabus.Infrastructure.Data.Configuration
             builder.Property(e => e.EmailVerified);
 
             builder.Property(e => e.ProfilePictureUrl)
-                .HasMaxLength(500);
+                .HasMaxLength(500)
+                .IsRequired(false);
 
             builder.Property(e => e.Status)
                 .HasConversion<string>();

--- a/Syllabus.Infrastructure/Migrations/20250524152104_MakeProfilePictureUrlNullable.Designer.cs
+++ b/Syllabus.Infrastructure/Migrations/20250524152104_MakeProfilePictureUrlNullable.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Syllabus.Infrastructure.Data;
 
@@ -11,9 +12,11 @@ using Syllabus.Infrastructure.Data;
 namespace Syllabus.Infrastructure.Migrations
 {
     [DbContext(typeof(SyllabusDbContext))]
-    partial class SyllabusDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250524152104_MakeProfilePictureUrlNullable")]
+    partial class MakeProfilePictureUrlNullable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Syllabus.Infrastructure/Migrations/20250524152104_MakeProfilePictureUrlNullable.cs
+++ b/Syllabus.Infrastructure/Migrations/20250524152104_MakeProfilePictureUrlNullable.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Syllabus.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class MakeProfilePictureUrlNullable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "ProfilePictureUrl",
+                table: "Users",
+                type: "nvarchar(500)",
+                maxLength: 500,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(500)",
+                oldMaxLength: 500);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "ProfilePictureUrl",
+                table: "Users",
+                type: "nvarchar(500)",
+                maxLength: 500,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(500)",
+                oldMaxLength: 500,
+                oldNullable: true);
+        }
+    }
+}

--- a/SyllabusAPI/Program.cs
+++ b/SyllabusAPI/Program.cs
@@ -115,10 +115,16 @@ using (var scope = app.Services.CreateScope())
             FirstName = "System",
             LastName = "Administrator",
             PhoneNumber = "+355123456789",
-            PhoneNumberConfirmed = true
+            PhoneNumberConfirmed = true,
+            ProfilePictureUrl = string.Empty,
+            PhoneNumberInfo = new PhoneNumber
+            {
+                Prefix = "+355",
+                Number = "123456789"
+            }
         };
 
-        var result = await userManager.CreateAsync(adminUser, "Admin@123!"); // This is a temporary password that should be changed immediately
+        var result = await userManager.CreateAsync(adminUser, "Admin@123!");
         if (result.Succeeded)
         {
             await userManager.AddToRoleAsync(adminUser, UserRole.Administrator.ToString());


### PR DESCRIPTION
Updated the ProfilePictureUrl property in UserEntity to be nullable. Adjusted UserEntityConfiguration to reflect this change in the database schema. Added migration to alter the Users table for nullable ProfilePictureUrl. Updated the model snapshot and modified admin user creation in Program.cs to initialize ProfilePictureUrl and set PhoneNumberInfo.